### PR TITLE
Feature/jwt auth: 회원가입, 로그인, 프로필 불러오기

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "axios": "^1.7.7",
     "prettier": "^3.3.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -3,6 +3,10 @@ import axios from 'axios';
 const API_URL = 'https://moneyfulpublicpolicy.co.kr';
 
 export const register = async (userData) => {
-  const response = await axios.post(`${API_URL}/register`, userData);
-  return response.data;
+  try {
+    const response = await axios.post(`${API_URL}/register`, userData);
+    return response.data;
+  } catch (error) {
+    return error.response.data;
+  }
 };

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -19,3 +19,12 @@ export const login = async (userData) => {
     return error.response.data;
   }
 };
+
+export const fetchProfile = async (accessToken) => {
+  try {
+    const response = await axios.get(`${API_URL}/user`, { headers: { Authorization: `Bearer ${accessToken}` } });
+    return response.data;
+  } catch (error) {
+    return error.response.data;
+  }
+};

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -10,3 +10,12 @@ export const register = async (userData) => {
     return error.response.data;
   }
 };
+
+export const login = async (userData) => {
+  try {
+    const response = await axios.post(`${API_URL}/login`, userData);
+    return response.data;
+  } catch (error) {
+    return error.response.data;
+  }
+};

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -1,0 +1,8 @@
+import axios from 'axios';
+
+const API_URL = 'https://moneyfulpublicpolicy.co.kr';
+
+export const register = async (userData) => {
+  const response = await axios.post(`${API_URL}/register`, userData);
+  return response.data;
+};

--- a/src/components/Input/AuthForm.jsx
+++ b/src/components/Input/AuthForm.jsx
@@ -1,0 +1,46 @@
+import FormInput from './FormInput.jsx';
+import Button from './Button.jsx';
+
+const AuthForm = ({ mode, onSubmit, formValue, setFormValue }) => {
+  return (
+    <form
+      className='border rounded p-5 max-w-[800px] bg-gray-200 flex flex-col justify-center items-center gap-5 py-[30px]'
+      onSubmit={onSubmit}
+    >
+      <FormInput
+        placeholder='아이디'
+        name='id'
+        type='text'
+        value={formValue}
+        setValue={setFormValue}
+        className='w-[300px]'
+      />
+      <FormInput
+        placeholder='비밀번호'
+        name='password'
+        type='password'
+        value={formValue}
+        setValue={setFormValue}
+        className='w-[300px]'
+      />
+      {mode === 'signup' ? (
+        <FormInput
+          placeholder='닉네임'
+          name='nickname'
+          type='text'
+          value={formValue}
+          setValue={setFormValue}
+          className='w-[300px]'
+        />
+      ) : null}
+      <Button
+        type='submit'
+        className='rounded w-full h-[35px] bg-primary-bg-red font-bold text-point-red'
+      >
+        {mode === 'signup' ? '회원가입' : '로그인'}
+      </Button>
+    </form>
+  );
+};
+
+export default AuthForm;

--- a/src/components/Input/Button.jsx
+++ b/src/components/Input/Button.jsx
@@ -1,0 +1,14 @@
+const Button = ({ children, type, onSubmit, onClick, ...props }) => {
+  return (
+    <button
+      type={type}
+      onSubmit={onSubmit}
+      onClick={onClick}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+};
+
+export default Button;

--- a/src/components/Input/Button.jsx
+++ b/src/components/Input/Button.jsx
@@ -1,8 +1,8 @@
-const Button = ({ children, type, onSubmit, onClick, ...props }) => {
+const Button = ({ children, type, className, onClick, ...props }) => {
   return (
     <button
+      className={className}
       type={type}
-      onSubmit={onSubmit}
       onClick={onClick}
       {...props}
     >

--- a/src/components/Input/FormInput.jsx
+++ b/src/components/Input/FormInput.jsx
@@ -1,0 +1,21 @@
+const FormInput = ({ label, name, type, value, setValue, className, ...props }) => {
+  const handleChange = (e) => {
+    setValue({ ...value, [e.target.name]: e.target.value });
+  };
+
+  return (
+    <div className={label ? 'grid grid-cols-[1fr_3fr]' : 'w-full'}>
+      <span>{label}</span>
+      <input
+        className={`border rounded h-[35px] px-2 ${className}`}
+        name={name}
+        type={type}
+        value={value.name}
+        onChange={handleChange}
+        {...props}
+      />
+    </div>
+  );
+};
+
+export default FormInput;

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -3,7 +3,7 @@ import { userContext } from '../../context/userContextProvider.jsx';
 import { useContext } from 'react';
 
 const Header = () => {
-  const { user } = useContext(userContext);
+  const { isAuthenticated } = useContext(userContext);
 
   return (
     <header className='fixed top-0 w-full flex justify-between items-center h-[50px] px-5 bg-white shadow-lg shadow-gray-500/50'>
@@ -11,7 +11,7 @@ const Header = () => {
         <Link to='/'>홈</Link>
       </div>
       <div className='flex gap-3'>
-        {user ? (
+        {isAuthenticated ? (
           <>
             <Link to='/test'>테스트</Link>
             <Link to='/results'>결과 보기</Link>

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -1,9 +1,15 @@
 import { Link } from 'react-router-dom';
 import { userContext } from '../../context/userContextProvider.jsx';
 import { useContext } from 'react';
+import Button from '../Input/Button.jsx';
 
 const Header = () => {
-  const { isAuthenticated } = useContext(userContext);
+  const { isAuthenticated, setLogout } = useContext(userContext);
+
+  const handleLogout = () => {
+    alert('로그아웃 완료!');
+    setLogout();
+  };
 
   return (
     <header className='fixed top-0 w-full flex justify-between items-center h-[50px] px-5 bg-white shadow-lg shadow-gray-500/50'>
@@ -16,6 +22,12 @@ const Header = () => {
             <Link to='/test'>테스트</Link>
             <Link to='/results'>결과 보기</Link>
             <Link to='/profile'>프로필</Link>
+            <Button
+              type='button'
+              onClick={handleLogout}
+            >
+              로그아웃
+            </Button>
           </>
         ) : (
           <>

--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -6,7 +6,7 @@ const Layout = () => {
   return (
     <>
       <Header />
-      <main className='mt-[50px]'>
+      <main className='flex justify-center mt-[50px] bg-gray-100'>
         <Outlet />
       </main>
       <Footer />

--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -4,13 +4,13 @@ import Footer from './Footer.jsx';
 
 const Layout = () => {
   return (
-    <>
+    <div className='flex flex-col h-full'>
       <Header />
-      <main className='flex justify-center mt-[50px] bg-gray-100'>
+      <main className='flex justify-center mt-[50px] bg-gray-100 flex-1'>
         <Outlet />
       </main>
       <Footer />
-    </>
+    </div>
   );
 };
 

--- a/src/context/userContextProvider.jsx
+++ b/src/context/userContextProvider.jsx
@@ -1,11 +1,23 @@
 import { createContext, useState } from 'react';
 
+const accessToken = localStorage.getItem('accessToken');
+
 export const userContext = createContext();
 
 const UserContextProvider = ({ children }) => {
-  const [user, setUser] = useState(true);
+  const [isAuthenticated, setIsAuthenticated] = useState(!!accessToken);
 
-  return <userContext.Provider value={{ user }}>{children}</userContext.Provider>;
+  const setLogin = (token) => {
+    localStorage.setItem('accessToken', token);
+    setIsAuthenticated(true);
+  };
+
+  const setLogout = () => {
+    localStorage.removeItem('accessToken');
+    setIsAuthenticated(false);
+  };
+
+  return <userContext.Provider value={{ isAuthenticated, setLogin, setLogout }}>{children}</userContext.Provider>;
 };
 
 export default UserContextProvider;

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -1,5 +1,41 @@
+import { useEffect, useState } from 'react';
+import { fetchProfile } from '../api/auth.js';
+import Button from '../components/Input/Button.jsx';
+
 const Profile = () => {
-  return <div>Profile</div>;
+  const [userProfile, setUserProfile] = useState();
+  const accessToken = localStorage.getItem('accessToken');
+
+  // TODO: 지난번에 한 render as you fetch 적용해보기
+  useEffect(() => {
+    (async () => {
+      const { success, ...profileData } = await fetchProfile(accessToken);
+
+      if (success) {
+        setUserProfile(profileData);
+      } else {
+        // TODO: 실패시 조치 추가
+        alert('프로필 불러오기에 실패했습니다.');
+      }
+    })();
+  }, []);
+  return (
+    <div className='flex flex-col gap-5 m-10'>
+      <h2 className='font-bold text-2xl'>
+        안녕하세요 <span>{userProfile?.nickname}</span>님!
+      </h2>
+      {/*TODO: 프로필 변경 기능 추가*/}
+      <Button
+        className='rounded w-full bg-primary-bg-red text-point-red font-bold'
+        type='button'
+        onClick={() => {
+          alert('준비중! 조금만 기다려주세요');
+        }}
+      >
+        프로필 변경하기
+      </Button>
+    </div>
+  );
 };
 
 export default Profile;

--- a/src/pages/SignIn.jsx
+++ b/src/pages/SignIn.jsx
@@ -1,5 +1,81 @@
+import { useContext, useState } from 'react';
+import { login } from '../api/auth.js';
+import { userContext } from '../context/userContextProvider.jsx';
+import { Link, Navigate } from 'react-router-dom';
+import FormInput from '../components/Input/FormInput.jsx';
+import Button from '../components/Input/Button.jsx';
+
 const SignIn = () => {
-  return <div>SignIn</div>;
+  const [formValue, setFormValue] = useState({ id: '', password: '' });
+
+  const { setLogin } = useContext(userContext);
+  const [logedIn, setLogedIn] = useState(false);
+  const handleSignIn = async (e) => {
+    e.preventDefault();
+    const { accessToken, userId, success, avatar, nickname } = await login(formValue);
+
+    let alertMessage;
+    if (success) {
+      setLogin(accessToken);
+      alertMessage = '로그인 성공! 마이페이지로 이동합니다.';
+    } else {
+      alertMessage = '아이디/비밀번호를 다시 확인해주세요.';
+    }
+
+    alert(alertMessage);
+    setLogedIn(true);
+  };
+
+  if (logedIn) {
+    return (
+      <Navigate
+        to='/profile'
+        replace={true}
+      />
+    );
+  }
+
+  return (
+    <div className='flex flex-col justify-center items-center bg-white w-[500px] p-8 rounded shadow-md'>
+      <h2 className='font-bold mb-2'>로그인</h2>
+      <form
+        className='border rounded p-5 max-w-[800px] bg-gray-200 flex flex-col justify-center items-center gap-5 py-[30px]'
+        onSubmit={handleSignIn}
+      >
+        <FormInput
+          placeholder='아이디'
+          name='id'
+          type='text'
+          value={formValue}
+          setValue={setFormValue}
+          className='w-[300px]'
+        />
+        <FormInput
+          placeholder='비밀번호'
+          name='password'
+          type='password'
+          value={formValue}
+          setValue={setFormValue}
+          className='w-[300px]'
+        />
+        <Button
+          type='submit'
+          className='rounded w-full h-[35px] bg-primary-bg-red font-bold text-point-red'
+        >
+          로그인
+        </Button>
+        <div className='flex gap-2'>
+          <p>계정이 없으신가요?</p>
+          <Link
+            to='/sign-up'
+            className='font-bold text-point-red'
+          >
+            회원가입
+          </Link>
+        </div>
+      </form>
+    </div>
+  );
 };
 
 export default SignIn;

--- a/src/pages/SignIn.jsx
+++ b/src/pages/SignIn.jsx
@@ -2,8 +2,7 @@ import { useContext, useState } from 'react';
 import { login } from '../api/auth.js';
 import { userContext } from '../context/userContextProvider.jsx';
 import { Link, Navigate } from 'react-router-dom';
-import FormInput from '../components/Input/FormInput.jsx';
-import Button from '../components/Input/Button.jsx';
+import AuthForm from '../components/Input/AuthForm.jsx';
 
 const SignIn = () => {
   const [formValue, setFormValue] = useState({ id: '', password: '' });
@@ -12,7 +11,7 @@ const SignIn = () => {
   const [logedIn, setLogedIn] = useState(false);
   const handleSignIn = async (e) => {
     e.preventDefault();
-    const { accessToken, userId, success, avatar, nickname } = await login(formValue);
+    const { accessToken, success } = await login(formValue);
 
     let alertMessage;
     if (success) {
@@ -36,44 +35,23 @@ const SignIn = () => {
   }
 
   return (
-    <div className='flex flex-col justify-center items-center bg-white w-[500px] p-8 rounded shadow-md'>
+    <div className='flex flex-col justify-center items-center self-center gap-5 bg-white w-[500px] h-[400px] p-8 rounded shadow-md'>
       <h2 className='font-bold mb-2'>로그인</h2>
-      <form
-        className='border rounded p-5 max-w-[800px] bg-gray-200 flex flex-col justify-center items-center gap-5 py-[30px]'
+      <AuthForm
+        mode='signin'
         onSubmit={handleSignIn}
-      >
-        <FormInput
-          placeholder='아이디'
-          name='id'
-          type='text'
-          value={formValue}
-          setValue={setFormValue}
-          className='w-[300px]'
-        />
-        <FormInput
-          placeholder='비밀번호'
-          name='password'
-          type='password'
-          value={formValue}
-          setValue={setFormValue}
-          className='w-[300px]'
-        />
-        <Button
-          type='submit'
-          className='rounded w-full h-[35px] bg-primary-bg-red font-bold text-point-red'
+        formValue={formValue}
+        setFormValue={setFormValue}
+      />
+      <div className='flex gap-2'>
+        <p>계정이 없으신가요?</p>
+        <Link
+          to='/sign-up'
+          className='font-bold text-point-red'
         >
-          로그인
-        </Button>
-        <div className='flex gap-2'>
-          <p>계정이 없으신가요?</p>
-          <Link
-            to='/sign-up'
-            className='font-bold text-point-red'
-          >
-            회원가입
-          </Link>
-        </div>
-      </form>
+          회원가입
+        </Link>
+      </div>
     </div>
   );
 };

--- a/src/pages/SignUp.jsx
+++ b/src/pages/SignUp.jsx
@@ -16,14 +16,20 @@ const SignUp = () => {
   const handleSignUp = async (e) => {
     e.preventDefault();
     const { message, success } = await register(formValue);
-    alert(message);
+
+    let alertMessage = message;
+    if (success) {
+      alertMessage += ' 로그인해주세요!';
+    }
+
+    alert(alertMessage);
     setSignedUp(success);
   };
 
   if (signedUp) {
     return (
       <Navigate
-        to='/'
+        to='/sign-in'
         replace={true}
       />
     );

--- a/src/pages/SignUp.jsx
+++ b/src/pages/SignUp.jsx
@@ -1,5 +1,61 @@
+import { useState } from 'react';
+import FormInput from '../components/Input/FormInput.jsx';
+import Button from '../components/Input/Button.jsx';
+import { Link } from 'react-router-dom';
+
 const SignUp = () => {
-  return <div>Sign Up</div>;
+  const [formValue, setFormValue] = useState({
+    id: '',
+    password: '',
+    nickname: '',
+  });
+
+  return (
+    <div className='flex flex-col justify-center items-center bg-white w-[500px] p-8 rounded shadow-md'>
+      <h2 className='font-bold mb-2'>회원가입</h2>
+      <form className='border rounded p-5 max-w-[800px] bg-gray-200 flex flex-col justify-center items-center gap-5 py-[30px]'>
+        <FormInput
+          placeholder='아이디'
+          name='id'
+          type='text'
+          value={formValue}
+          setValue={setFormValue}
+          className='w-[300px]'
+        />
+        <FormInput
+          placeholder='비밀번호'
+          name='password'
+          type='password'
+          value={formValue}
+          setValue={setFormValue}
+          className='w-[300px]'
+        />
+        <FormInput
+          placeholder='닉네임'
+          name='nickname'
+          type='text'
+          value={formValue}
+          setValue={setFormValue}
+          className='w-[300px]'
+        />
+        <Button
+          type='submit'
+          className='rounded w-full h-[35px] bg-primary-bg-red font-bold text-point-red'
+        >
+          회원가입
+        </Button>
+        <div className='flex gap-2'>
+          <p>이미 계정이 있으신가요?</p>
+          <Link
+            to='/sign-in'
+            className='font-bold text-point-red'
+          >
+            로그인
+          </Link>
+        </div>
+      </form>
+    </div>
+  );
 };
 
 export default SignUp;

--- a/src/pages/SignUp.jsx
+++ b/src/pages/SignUp.jsx
@@ -1,9 +1,8 @@
 import { useState } from 'react';
-import FormInput from '../components/Input/FormInput.jsx';
-import Button from '../components/Input/Button.jsx';
 import { Link } from 'react-router-dom';
 import { register } from '../api/auth.js';
 import { Navigate } from 'react-router-dom';
+import AuthForm from '../components/Input/AuthForm.jsx';
 
 const SignUp = () => {
   const [formValue, setFormValue] = useState({
@@ -36,52 +35,23 @@ const SignUp = () => {
   }
 
   return (
-    <div className='flex flex-col justify-center items-center bg-white w-[500px] p-8 rounded shadow-md'>
+    <div className='flex flex-col justify-center items-center self-center gap-5 bg-white w-[500px] p-10 rounded shadow-md'>
       <h2 className='font-bold mb-2'>회원가입</h2>
-      <form
-        className='border rounded p-5 max-w-[800px] bg-gray-200 flex flex-col justify-center items-center gap-5 py-[30px]'
+      <AuthForm
+        mode='signup'
         onSubmit={handleSignUp}
-      >
-        <FormInput
-          placeholder='아이디'
-          name='id'
-          type='text'
-          value={formValue}
-          setValue={setFormValue}
-          className='w-[300px]'
-        />
-        <FormInput
-          placeholder='비밀번호'
-          name='password'
-          type='password'
-          value={formValue}
-          setValue={setFormValue}
-          className='w-[300px]'
-        />
-        <FormInput
-          placeholder='닉네임'
-          name='nickname'
-          type='text'
-          value={formValue}
-          setValue={setFormValue}
-          className='w-[300px]'
-        />
-        <Button
-          type='submit'
-          className='rounded w-full h-[35px] bg-primary-bg-red font-bold text-point-red'
+        formValue={formValue}
+        setFormValue={setFormValue}
+      />
+      <div className='flex gap-2'>
+        <p>이미 계정이 있으신가요?</p>
+        <Link
+          to='/sign-in'
+          className='font-bold text-point-red'
         >
-          회원가입
-        </Button>
-        <div className='flex gap-2'>
-          <p>이미 계정이 있으신가요?</p>
-          <Link
-            to='/sign-in'
-            className='font-bold text-point-red'
-          >
-            로그인
-          </Link>
-        </div>
-      </form>
+          로그인
+        </Link>
+      </div>
     </div>
   );
 };

--- a/src/pages/SignUp.jsx
+++ b/src/pages/SignUp.jsx
@@ -2,6 +2,8 @@ import { useState } from 'react';
 import FormInput from '../components/Input/FormInput.jsx';
 import Button from '../components/Input/Button.jsx';
 import { Link } from 'react-router-dom';
+import { register } from '../api/auth.js';
+import { Navigate } from 'react-router-dom';
 
 const SignUp = () => {
   const [formValue, setFormValue] = useState({
@@ -10,10 +12,30 @@ const SignUp = () => {
     nickname: '',
   });
 
+  const [signedUp, setSignedUp] = useState(false);
+  const handleSignUp = async (e) => {
+    e.preventDefault();
+    const { message, success } = await register(formValue);
+    alert(message);
+    setSignedUp(success);
+  };
+
+  if (signedUp) {
+    return (
+      <Navigate
+        to='/'
+        replace={true}
+      />
+    );
+  }
+
   return (
     <div className='flex flex-col justify-center items-center bg-white w-[500px] p-8 rounded shadow-md'>
       <h2 className='font-bold mb-2'>회원가입</h2>
-      <form className='border rounded p-5 max-w-[800px] bg-gray-200 flex flex-col justify-center items-center gap-5 py-[30px]'>
+      <form
+        className='border rounded p-5 max-w-[800px] bg-gray-200 flex flex-col justify-center items-center gap-5 py-[30px]'
+        onSubmit={handleSignUp}
+      >
         <FormInput
           placeholder='아이디'
           name='id'

--- a/src/reset.css
+++ b/src/reset.css
@@ -6,6 +6,10 @@
     box-sizing: border-box;
 }
 
+html, body, #root {
+    height: 100%;
+}
+
 html, body, div, span, applet, object, iframe,
 h1, h2, h3, h4, h5, h6, p, blockquote, pre,
 a, abbr, acronym, address, big, cite, code,

--- a/src/shared/ProtectedRoute.jsx
+++ b/src/shared/ProtectedRoute.jsx
@@ -3,9 +3,9 @@ import { userContext } from '../context/userContextProvider.jsx';
 import { useContext } from 'react';
 
 const ProtectedRoute = () => {
-  const { user } = useContext(userContext);
+  const { isAuthenticated } = useContext(userContext);
   const { pathname } = useLocation();
-  if (!user) {
+  if (!isAuthenticated) {
     return (
       <Navigate
         to='/sign-in'

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,9 +1,13 @@
 /** @type {import('tailwindcss').Config} */
 export default {
-  content: ["./index.html", "./src/**/*.{js,jsx,ts,tsx}"],
+  content: ['./index.html', './src/**/*.{js,jsx,ts,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        'primary-bg-red': '#ffdfdf',
+        'point-red': '#ff7676',
+      },
+    },
   },
   plugins: [],
-}
-
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -737,6 +737,11 @@ arraybuffer.prototype.slice@^1.0.3:
     is-array-buffer "^3.0.4"
     is-shared-array-buffer "^1.0.2"
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
 autoprefixer@^10.4.20:
   version "10.4.20"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-10.4.20.tgz#5caec14d43976ef42e32dcb4bd62878e96be5b3b"
@@ -755,6 +760,15 @@ available-typed-arrays@^1.0.7:
   integrity sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==
   dependencies:
     possible-typed-array-names "^1.0.0"
+
+axios@^1.7.7:
+  version "1.7.7"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.7.tgz#2f554296f9892a72ac8d8e4c5b79c14a91d0a47f"
+  integrity sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 balanced-match@^1.0.0:
   version "1.0.2"
@@ -880,6 +894,13 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 commander@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
@@ -970,6 +991,11 @@ define-properties@^1.1.3, define-properties@^1.2.0, define-properties@^1.2.1:
     define-data-property "^1.0.1"
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 didyoumean@^1.2.2:
   version "1.2.2"
@@ -1361,6 +1387,11 @@ flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.1.tgz#21db470729a6734d4997002f439cb308987f567a"
   integrity sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==
 
+follow-redirects@^1.15.6:
+  version "1.15.9"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
+  integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
+
 for-each@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
@@ -1375,6 +1406,15 @@ foreground-child@^3.1.0:
   dependencies:
     cross-spawn "^7.0.0"
     signal-exit "^4.0.1"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 fraction.js@^4.3.7:
   version "4.3.7"
@@ -1898,6 +1938,18 @@ micromatch@^4.0.4, micromatch@^4.0.5:
     braces "^3.0.3"
     picomatch "^2.3.1"
 
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.12:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
+
 minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
@@ -2171,6 +2223,11 @@ prop-types@^15.8.1:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 punycode@^2.1.0:
   version "2.3.1"


### PR DESCRIPTION
## What is this PR? 🔍
- SignUp, SignIn, Profile 기본 구조 설정
- 회원가입 요청 및 정상처리 후 로그인 페이지로 이동
- 로그인 요청 및 정상처리 후 userContext의 isAuthenticated 설정 + 프로필 페이지로 이동
- 프로필 페이지에서 유저 정보 fetch 후 닉네임 표시

<br/>

## Screenshot 📸
![auth마무리](https://github.com/user-attachments/assets/b815c0ff-60d9-46cb-9995-b83700a70593)

<br/>

## Test Checklist ☑️
- [x] 회원가입/로그인 오류시 오류메시지 alert 되는 것 확인
- [x] 회원가입/로그인 정상 처리시 다음 Page로 연결되는 것 확인
- [x] 입력한 유저 정보 정상 fetch되는 것 확인
- [x] 로그인 여부에 따라 Header의 Link/Button 태그 적절히 렌더링되는 것 확인

<br/>

## Others 👻
- MBTI 테스트 및 결과 확인 기능 구현 후 프로필 변경 기능 추가 필요